### PR TITLE
Added support for newsyslog.

### DIFF
--- a/syslog-mode.el
+++ b/syslog-mode.el
@@ -202,6 +202,9 @@
     map)
   "The local keymap for `syslog-mode'.")
 
+(defvar syslog-number-suffix-start 1
+  "The first number used as rotation suffix.")
+
 (defun syslog-get-basename-and-number (filename)
   "Return the basename and number suffix of a log file in FILEPATH.
 Return results in a cons cell '(basename . number) where basename is a string,
@@ -209,7 +212,7 @@ and number is a number."
   (let* ((res (string-match "\\(.*?\\)\\.\\([0-9]+\\)\\(\\.t?gz\\)?" filename))
          (basename (if res (match-string 1 filename) filename))
          (str (and res (match-string 2 filename)))
-         (num (or (and str (string-to-number str)) 0)))
+         (num (or (and str (string-to-number str)) (1- syslog-number-suffix-start))))
     (cons basename num)))
 
 (defun syslog-open-files (filename num)
@@ -252,11 +255,13 @@ one if ARG is non-nil."
          (basename (car pair))
          (curver (cdr pair))
          (nextver (if arg (1- curver) (1+ curver)))
-         (nextfile (if (> nextver 0)
+         (nextfile (if (> nextver (1- syslog-number-suffix-start))
                        (concat basename "." (number-to-string nextver))
                      basename)))
     (cond ((file-readable-p nextfile)
            (find-file nextfile))
+          ((file-readable-p (concat nextfile ".bz2"))
+           (find-file (concat nextfile ".bz2")))
           ((file-readable-p (concat nextfile ".gz"))
            (find-file (concat nextfile ".gz")))
           ((file-readable-p (concat nextfile ".tgz"))


### PR DESCRIPTION
[Newsyslog](http://www.freebsd.org/cgi/man.cgi?query=newsyslog&sektion=8) used on FreeBSD and Mac OS X has the option to compress using bzip2.

It also starts it number suffix at 0 instead of at 1 like logrotate.

Added a check for the existing of a .bz2 extension in `syslog-previous-file` and added a configurable start number for
rotation number suffix (`syslog-number-suffix-start`).

With this change I'll be able to get `syslog-mode` do the right thing on my Mac by adding this snippet to my init file:

``` lisp
  (when (eq system-type 'darwin)
    (setq syslog-boot-start-regexp "BOOT_TIME")
    (setq syslog-number-suffix-start 0))
```
