### PR TITLE
Deleted the markdown README that obscured the org README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,0 @@
-syslog-mode
-===========
-
-Emacs major-mode for viewing log files


### PR DESCRIPTION
The README.org file has more information than the README.md file, and
with the README.md file gone, the org file will be displayed on github.
